### PR TITLE
Fix possible index out of range condition in LookupIP()

### DIFF
--- a/client.go
+++ b/client.go
@@ -152,9 +152,12 @@ func (c *Client) LookupIPs(ips []net.IP) (resp []Response, err error) {
 }
 
 //LookupIP is a single IP convenience proxy of LookupIPs
-func (c *Client) LookupIP(ip net.IP) (Response, error) {
+func (c *Client) LookupIP(ip net.IP) (*Response, error) {
 	resp, err := c.LookupIPs([]net.IP{ip})
-	return resp[0], err
+	if len(resp) == 0 {
+		return nil, err
+	}
+	return &resp[0], err
 }
 
 //LookupASNs looks up ASNs. Response IP and Range fields are zeroed


### PR DESCRIPTION
Although I'm not able to reproduce it or be able to explain it, I got this stack trace.
Figured I might as well prevent it.

panic: runtime error: index out of range

goroutine 70 [running]:
panic(0xd1d140, 0xc820010120)
/opt/go/src/runtime/panic.go:464 +0x3e6
github.com/ammario/ipisp.(*Client).LookupIP(0xc8202a6480, 0xc82025a8d0, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
/home/dolf/Projects/Cluegetter/src/github.com/ammario/ipisp/client.go:157 +0x110
