### PR TITLE
 Simple fix for issues with AS Name

### DIFF
--- a/dns_client.go
+++ b/dns_client.go
@@ -20,7 +20,7 @@ func NewDNSClient() (client *DNSClient, err error) {
 }
 
 func (c *DNSClient) LookupIPs(ips []net.IP) ([]Response, error) {
-	ret := make([]Response, len(ips))
+	var ret []Response
 
 	for _, ip := range ips {
 		resp, err := c.LookupIP(ip)

--- a/name.go
+++ b/name.go
@@ -11,7 +11,7 @@ type Name struct {
 
 //ParseName returns a pointer to a new name
 func ParseName(raw string) Name {
-	tokens := strings.Split(raw, "-")
+	tokens := strings.Split(raw, " - ")
 	if len(tokens) == 0 {
 		tokens = []string{raw}
 	}


### PR DESCRIPTION
This simple fix addresses issues where the AS name contains a `-`.  By adding spaces around the separator, the name is preserved instead of truncated.
