### PR TITLE
Remove the strings package dependency from the whois_client.go file

### DIFF
--- a/whois_client.go
+++ b/whois_client.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -141,7 +140,7 @@ func (c *whoisClient) LookupIPs(ips []net.IP) (resp []Response, err error) {
 		}
 
 		// Read country
-		re.Country = strings.TrimSpace(string(tokens[3]))
+		re.Country = string(bytes.TrimSpace(tokens[3]))
 
 		// Read registry
 		re.Registry = string(bytes.ToUpper(tokens[4]))


### PR DESCRIPTION
Removing the `strings` package by using `bytes.TrimSpace` rather than `strings.TrimSpace` in the `whois_client.go` file