### PR TITLE
[fix] empty responses when lookup multiple IPs

### DIFF
--- a/dns_client.go
+++ b/dns_client.go
@@ -21,7 +21,7 @@ func NewDNSClient() (Client, error) {
 }
 
 func (c *dnsClient) LookupIPs(ips []net.IP) ([]Response, error) {
-	ret := make([]Response, len(ips))
+	ret := make([]Response, 0, len(ips))
 
 	for _, ip := range ips {
 		resp, err := c.LookupIP(ip)


### PR DESCRIPTION
This PR fixes empty response when trying to lookup multiple IPs using DNS client:

code:

```go
	const host = "github.com"
	ips, err := net.LookupIP(host)
	if err != nil {
		log.Fatalf("Failed to ip: %v", err)
	}
	fmt.Println(ips)

	client, err := ipisp.NewDNSClient()
	if err != nil {
		log.Fatalf("Failed to create client: %v", err)
	}
	defer client.Close()

	resp, err := client.LookupIPs(ips)
	if err != nil {
		log.Fatalf("Error looking up 4.2.2.2: %v", err)
	}
	jsonres, err := json.Marshal(resp)
	fmt.Println(string(jsonres))
```

result:

```json
[
    {
        "AllocatedAt": "0001-01-01T00:00:00Z",
        "ASN": 0,
        "Country": "",
        "IP": "",
        "Name": {
            "Long": "",
            "Raw": "",
            "Short": ""
        },
        "Range": null,
        "Registry": ""
    },
    {
        "AllocatedAt": "2016-08-09T00:00:00Z",
        "ASN": 16509,
        "Country": "US",
        "IP": "13.229.188.59",
        "Name": {
            "Long": "AMAZON-02, US",
            "Raw": "AMAZON-02, US",
            "Short": "AMAZON-02, US"
        },
        "Range": {
            "IP": "13.228.0.0",
            "Mask": "//4AAA=="
        },
        "Registry": "ARIN"
    }
]
```